### PR TITLE
Corrige le type par défaut des index du gestionnaire d'énergie 03809

### DIFF
--- a/core/config/devices/03809.json
+++ b/core/config/devices/03809.json
@@ -2,8 +2,8 @@
     "03809": {
         "name": "Gestionnaire d'Energie",
 		"configuration": {
-							"version": "1.2",
-							"update": "Ajout Generic Type + release et versionning + NbUnit",
+							"version": "1.3",
+							"update": "Changement du type par défaut des index HP et HC",
 							"nbunit": "2",
                             "038091": {
 								"ref_legrand": "03809",
@@ -93,7 +93,7 @@
 					{
                         "name": "Index HP",
                         "type": "info",
-						"subtype": "string",
+						"subtype": "numeric",
                         "isVisible": 1,
 						"isHistorized": 1,
                         "unite": "",
@@ -108,7 +108,7 @@
 					{
                         "name": "Index HC",
                         "type": "info",
-						"subtype": "string",
+						"subtype": "numeric",
                         "isVisible": 1,
 						"isHistorized": 1,
                         "unite": "",

--- a/core/config/devices/3809.json
+++ b/core/config/devices/3809.json
@@ -2,8 +2,8 @@
     "03809": {
         "name": "Gestionnaire d'Energie",
 		"configuration": {
-							"version": "1.2",
-							"update": "Ajout Generic Type + release et versionning + NbUnit",
+							"version": "1.3",
+							"update": "Changement du type par défaut des index HP et HC",
 							"nbunit": "2",
                             "038091": {
 								"ref_legrand": "03809",
@@ -93,7 +93,7 @@
 					{
                         "name": "Index HP",
                         "type": "info",
-						"subtype": "string",
+						"subtype": "numeric",
                         "isVisible": 1,
 						"isHistorized": 1,
                         "unite": "",
@@ -108,7 +108,7 @@
 					{
                         "name": "Index HC",
                         "type": "info",
-						"subtype": "string",
+						"subtype": "numeric",
                         "isVisible": 1,
 						"isHistorized": 1,
                         "unite": "",


### PR DESCRIPTION
Voilà ma modeste contribution à ce superbe projet qui a donné une seconde jeunesse à nos si chères installations In One! 👏 

A noter: j'ai vu qu'il y avait 2 fichiers pour le gestionnaire d'énergie 03809 (un avec un 0, un sans) donc je me suis permis de modifier les deux.

https://github.com/apages2/pluginjeedom-boxio/issues/14