### PR TITLE
Corrige le chemin du logo In One by Legrand utilisé par défaut dans la vue santé

### DIFF
--- a/desktop/modal/health.php
+++ b/desktop/modal/health.php
@@ -44,7 +44,7 @@ foreach ($eqLogics as $eqLogic) {
 	} elseif (file_exists(dirname(__FILE__) . '/../../core/config/devices/' . $eqLogic->getConfiguration('device') . '.jpg')) {
 		$img = '<img class="lazy" src="plugins/boxio/core/config/devices/' . $eqLogic->getConfiguration('device') . '.jpg" height="65" width="55" />';
 	} else {
-		$img = '<img class="lazy" src="plugins/boxio/doc/images/boxio_icon.png" height="65" width="55" />';
+		$img = '<img class="lazy" src="plugins/boxio/plugin_info/boxio_icon.png" height="65" width="55" />';
 	}
 	$signalcmd = $eqLogic->getCmd('info', 'signal');
 	$signal = '';


### PR DESCRIPTION
Il semblerait que la doc' ne soit plus publiée avec le plugin et que le chemin utilisé jusque-là ne soit donc plus valide. A la place, je propose d'utiliser le fichier `boxio_icon.png` situé dans `plugin_info`.

![image](https://user-images.githubusercontent.com/6998306/89660145-378d6800-d8d1-11ea-908a-df6b8b22c579.png)
