### PR TITLE
Vérifie que l'info d'un scénario existe avant de créer un événement associé

### DIFF
--- a/core/class/boxio.class.php
+++ b/core/class/boxio.class.php
@@ -2162,7 +2162,6 @@ public static function updateStatusConfort($decrypted_trame, $scenarios=false) {
 		//On arrete l'action si celle ci est de type specifique
 		if ($decrypted_trame['value'] == 'STOP_ACTION') {
 			return;
-		log::add('boxio','debug',"action de type :".$decrypted_trame['value']);
 		}
 		
 		//On recherche si le scenario n'est pas de type SECURITY, si oui on le met à jour en fonction des units
@@ -2175,8 +2174,10 @@ public static function updateStatusConfort($decrypted_trame, $scenarios=false) {
 		if ($family != 'SECURITY') {
 			log::add('boxio','debug',"Statusid : ".$statusid);
 			$boxiocmd = $boxio->getCmd('info', $statusid);
-			$boxiocmd->event($value);
-			$boxiocmd->save();
+			if (isset($boxiocmd)) {
+				$boxiocmd->event($value);
+				$boxiocmd->save();
+			}
 		}
 						
 		//Mise a jour de  l'equipement lighting


### PR DESCRIPTION
boxio.class.php utilise presque partout `isset` pour vérifier si la source d'un scénario a bien une info avant de créer un événement. Dans ce cas précis, `isset` n'était pas utilisé et ça créait une erreur à la ligne 2178, empêchant les éléments associés au scénario d'être mis à jour.